### PR TITLE
:bug: モバイルでVideo再生されない問題を解決

### DIFF
--- a/apps/frontend/src/features/hero-content/components/HeroContent.tsx
+++ b/apps/frontend/src/features/hero-content/components/HeroContent.tsx
@@ -14,6 +14,7 @@ export const HeroContent = (): JSX.Element => {
         autoPlay
         muted
         loop
+        playsInline
         className="object-cover h-screen w-screen"
       ></video>
     </div>


### PR DESCRIPTION
## Issue

- close #129 

## 概要
iPhoneでヒーロー動画が再生されていなかったので、再生されるように修正を行いました。

## 参考リンク
https://senoweb.jp/note/tag-video/#:~:text=%E3%80%8CPC%E3%81%A7%E8%A6%8B%E3%81%9F%E3%81%A8%E3%81%8D,%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%99%E3%82%8C%E3%81%B0OK%E3%80%82