### PR TITLE
:recycle: Imageのalt属性をファイルパスからファイル名に修正

### DIFF
--- a/apps/frontend/src/features/advisor/components/AdvisorCard.tsx
+++ b/apps/frontend/src/features/advisor/components/AdvisorCard.tsx
@@ -26,7 +26,7 @@ export const AdvisorCard = ({
         <Image
           className="object-cover w-[150px] h-[150px] rounded-[50%]"
           src={advisorProfile.assets.src}
-          alt={advisorProfile.assets.src}
+          alt={advisorProfile.assets.file_name}
           width={advisorProfile.assets.width}
           height={advisorProfile.assets.height}
         />

--- a/apps/frontend/src/features/advisor/components/AdvisorProfileModal.tsx
+++ b/apps/frontend/src/features/advisor/components/AdvisorProfileModal.tsx
@@ -20,7 +20,7 @@ export const AdvisorProfileModal = ({
         {advisorProfile.assets ? (
           <Image
             src={advisorProfile.assets.src}
-            alt={advisorProfile.assets.src}
+            alt={advisorProfile.assets.file_name}
             width={advisorProfile.assets.width}
             height={advisorProfile.assets.height}
             className="object-cover w-[200px] h-[200px] rounded-[50%] m-auto mb-4"


### PR DESCRIPTION
## Issue

- close #150 🦕

## 概要

Imageのaltをsrcからfile_nameに修正しました。

## レビュー観点

altがsrcからfile_nameに変わったこと

## レビューレベル

<!-- どれかの打ち消し線を外してください。 -->

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [x] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

-

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |
